### PR TITLE
Add RQ queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Grec0AI Backend Worker
+
+Este proyecto contiene varios servicios que ejecutan scripts de procesamiento de videos, extracción de frames y metadatos utilizando contenedores Docker. Anteriormente los workers se implementaban con un bucle que leía colas de Redis manualmente. Ahora se ofrece una alternativa basada en **RQ** (Redis Queue) para gestionar las tareas de forma más robusta y en tiempo real.
+
+## Requisitos
+
+Instala las dependencias con:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+1. Añade trabajos a las colas correspondientes de RQ. Los nombres de las colas son:
+   - `scripts_queue`
+   - `video_scripts_queue`
+   - `frames_scripts_queue`
+   - `metadata_scripts_queue`
+
+2. Inicia el worker de RQ ejecutando:
+
+```bash
+python rq_worker.py
+```
+
+Los trabajos utilizan las funciones definidas en `app/services/rq_tasks.py`, las cuales hacen uso de los servicios existentes. De esta manera el flujo de procesamiento se mantiene, pero con las ventajas de una cola de trabajos real.

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -1,8 +1,15 @@
 import redis
+from rq import Queue
+from app.services import rq_tasks
 
 class RedisService:
     def __init__(self):
         self.r = redis.StrictRedis(host='127.0.0.1', port=6379, db=0)  # Configuración de Redis
+        # Colas de RQ para los distintos flujos
+        self.script_queue = Queue('scripts_queue', connection=self.r)
+        self.video_queue = Queue('video_scripts_queue', connection=self.r)
+        self.frames_queue = Queue('frames_scripts_queue', connection=self.r)
+        self.metadata_queue = Queue('metadata_scripts_queue', connection=self.r)
 
     def get_next_script(self):
         """Obtiene el siguiente script de la cola en Redis (flujo original)."""
@@ -65,3 +72,20 @@ class RedisService:
     def push_result(self, script_id, result):
         """Envía el resultado del script a Redis."""
         self.r.rpush(f"results_queue_{script_id}", result)
+
+    # --- Métodos para usar RQ ---
+    def enqueue_script(self, script_id: str, script_content: str):
+        """Encola la ejecución de un script como trabajo de RQ."""
+        self.script_queue.enqueue(rq_tasks.process_script_task, script_id, script_content)
+
+    def enqueue_video_conversion(self, script_id: str, script_content: str, video_id: str):
+        """Encola la conversión de video a audio."""
+        self.video_queue.enqueue(rq_tasks.process_video_task, script_id, script_content, video_id)
+
+    def enqueue_frames_extraction(self, script_id: str, script_content: str, video_id: str):
+        """Encola la extracción de frames de un video."""
+        self.frames_queue.enqueue(rq_tasks.process_frames_task, script_id, script_content, video_id)
+
+    def enqueue_metadata_extraction(self, script_id: str, script_content: str, video_id: str):
+        """Encola la extracción de metadatos de un video."""
+        self.metadata_queue.enqueue(rq_tasks.process_metadata_task, script_id, script_content, video_id)

--- a/app/services/rq_tasks.py
+++ b/app/services/rq_tasks.py
@@ -1,0 +1,31 @@
+from app.services.redis_service import RedisService
+from app.services.script_service import ScriptService
+from app.services.video_audio_service import VideoAudioService
+from app.services.frames_storage_service import FramesStorageService
+from app.services.metadata_storage_service import MetadataStorageService
+
+redis_service = RedisService()
+script_service = ScriptService(redis_service)
+video_audio_service = VideoAudioService(redis_service)
+frames_storage_service = FramesStorageService(redis_service)
+metadata_storage_service = MetadataStorageService(redis_service)
+
+
+def process_script_task(script_id: str, script_content: str):
+    """Process a script using the ScriptService."""
+    script_service.process_script(script_content, script_id)
+
+
+def process_video_task(script_id: str, script_content: str, video_id: str):
+    """Process a video conversion using the VideoAudioService."""
+    video_audio_service.process_video_conversion(script_content, script_id, video_id)
+
+
+def process_frames_task(script_id: str, script_content: str, video_id: str):
+    """Process frame extraction using the FramesStorageService."""
+    frames_storage_service.process_video_to_frames(script_content, script_id, video_id)
+
+
+def process_metadata_task(script_id: str, script_content: str, video_id: str):
+    """Process metadata extraction using the MetadataStorageService."""
+    metadata_storage_service.process_video_metadata(script_content, script_id, video_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 mysql-connector-python
 redis
 python-dotenv
+rq

--- a/rq_worker.py
+++ b/rq_worker.py
@@ -1,0 +1,16 @@
+from redis import Redis
+from rq import Worker, Queue, Connection
+
+listen = [
+    'scripts_queue',
+    'video_scripts_queue',
+    'frames_scripts_queue',
+    'metadata_scripts_queue'
+]
+
+redis_conn = Redis(host='127.0.0.1', port=6379, db=0)
+
+if __name__ == '__main__':
+    with Connection(redis_conn):
+        worker = Worker([Queue(name) for name in listen])
+        worker.work()


### PR DESCRIPTION
## Summary
- add RQ to dependencies
- create tasks for RQ queues
- provide worker script for RQ
- update RedisService with enqueue helpers
- document RQ usage

## Testing
- `python scripts/test.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f949a0688324af131ed693df4ec5