### PR TITLE
Add Frontend deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ redis_service.enqueue_frames_extraction("script_789", "script_content", "video_1
 
 # Trabajo de extracción de metadatos
 redis_service.enqueue_metadata_extraction("script_101", "script_content", "video_456")
+
+# Despliegue de un frontend desde código HTML
+html_code = "<h1>Hola</h1>"
+redis_service.enqueue_frontend_deployment("deploy_001", html_code)
+# Obtener la URL generada
+url = redis_service.r.blpop("results_queue_deploy_001")[1].decode("utf-8")
+print(url)
 ```
 
 #### Modo Tradicional
@@ -359,6 +366,7 @@ python main.py
 - `video_scripts_queue`: Scripts para conversión video-audio
 - `frames_scripts_queue`: Scripts para extracción de frames
 - `metadata_scripts_queue`: Scripts para extracción de metadatos
+- `frontend_queue`: Despliegue de frontends estáticos
 
 ## Especificaciones Técnicas
 

--- a/app/services/frontend_service.py
+++ b/app/services/frontend_service.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from typing import Optional
+
+
+class FrontendService:
+    def __init__(self, redis_service):
+        self.redis_service = redis_service
+
+    def _get_free_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            return s.getsockname()[1]
+
+    def deploy_frontend(self, image: str, deployment_id: str, port: Optional[int] = None) -> str:
+        """Run the given image exposing it on a host port and return the URL."""
+        host_port = port or self._get_free_port()
+        container_name = f"frontend_{deployment_id}"
+        self.redis_service.update_status(deployment_id, "in_progress")
+        try:
+            subprocess.run([
+                "docker", "run", "-d", "--rm",
+                "--name", container_name,
+                "-p", f"{host_port}:80",
+                image
+            ], check=True)
+            url = f"http://localhost:{host_port}"
+            self.redis_service.push_result(deployment_id, url)
+            self.redis_service.update_status(deployment_id, "completed")
+            return url
+        except subprocess.CalledProcessError as exc:
+            err = f"Error deploying frontend: {exc}"
+            self.redis_service.push_result(deployment_id, err)
+            self.redis_service.update_status(deployment_id, "failed")
+            raise
+
+    def build_and_deploy(self, code: str, deployment_id: str, port: Optional[int] = None) -> str:
+        """Build a simple nginx image from HTML code and deploy it."""
+        temp_dir = tempfile.mkdtemp(prefix=f"frontend_{deployment_id}_")
+        try:
+            index_path = os.path.join(temp_dir, "index.html")
+            with open(index_path, "w", encoding="utf-8") as f:
+                f.write(code)
+
+            dockerfile_path = os.path.join(temp_dir, "Dockerfile")
+            with open(dockerfile_path, "w", encoding="utf-8") as f:
+                f.write("FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\n")
+
+            image_tag = f"frontend:{deployment_id}"
+            subprocess.run(["docker", "build", "-t", image_tag, temp_dir], check=True)
+            return self.deploy_frontend(image_tag, deployment_id, port)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -10,6 +10,7 @@ class RedisService:
         self.video_queue = Queue('video_scripts_queue', connection=self.r)
         self.frames_queue = Queue('frames_scripts_queue', connection=self.r)
         self.metadata_queue = Queue('metadata_scripts_queue', connection=self.r)
+        self.frontend_queue = Queue('frontend_queue', connection=self.r)
 
     def get_next_script(self):
         """Obtiene el siguiente script de la cola en Redis (flujo original)."""
@@ -89,3 +90,7 @@ class RedisService:
     def enqueue_metadata_extraction(self, script_id: str, script_content: str, video_id: str):
         """Encola la extracción de metadatos de un video."""
         self.metadata_queue.enqueue(rq_tasks.process_metadata_task, script_id, script_content, video_id)
+
+    def enqueue_frontend_deployment(self, deployment_id: str, code: str, port: int | None = None):
+        """Encola el despliegue de un frontend desde código HTML."""
+        self.frontend_queue.enqueue(rq_tasks.deploy_frontend_from_code_task, code, deployment_id, port)

--- a/app/services/rq_tasks.py
+++ b/app/services/rq_tasks.py
@@ -3,12 +3,14 @@ from app.services.script_service import ScriptService
 from app.services.video_audio_service import VideoAudioService
 from app.services.frames_storage_service import FramesStorageService
 from app.services.metadata_storage_service import MetadataStorageService
+from app.services.frontend_service import FrontendService
 
 redis_service = RedisService()
 script_service = ScriptService(redis_service)
 video_audio_service = VideoAudioService(redis_service)
 frames_storage_service = FramesStorageService(redis_service)
 metadata_storage_service = MetadataStorageService(redis_service)
+frontend_service = FrontendService(redis_service)
 
 
 def process_script_task(script_id: str, script_content: str):
@@ -29,3 +31,8 @@ def process_frames_task(script_id: str, script_content: str, video_id: str):
 def process_metadata_task(script_id: str, script_content: str, video_id: str):
     """Process metadata extraction using the MetadataStorageService."""
     metadata_storage_service.process_video_metadata(script_content, script_id, video_id)
+
+
+def deploy_frontend_from_code_task(code: str, deployment_id: str, port: int | None = None):
+    """Build and deploy a frontend directly from HTML code."""
+    frontend_service.build_and_deploy(code, deployment_id, port)

--- a/rq_worker.py
+++ b/rq_worker.py
@@ -5,7 +5,8 @@ listen = [
     'scripts_queue',
     'video_scripts_queue',
     'frames_scripts_queue',
-    'metadata_scripts_queue'
+    'metadata_scripts_queue',
+    'frontend_queue'
 ]
 
 redis_conn = Redis(host='127.0.0.1', port=6379, db=0)


### PR DESCRIPTION
## Summary
- implement `FrontendService` capable of building and deploying HTML as an nginx container
- add new `deploy_frontend_from_code_task` RQ task
- allow enqueueing frontend deployments via `RedisService`
- listen to new queue in `rq_worker`
- document how to deploy a frontend and retrieve its URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846e3c30f448324b39788d4057b1f67