### PR TITLE
Implement frontend deployment service

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,3 +425,29 @@ Script ejecutado con éxito: output
 - Errores de ejecución se capturan y reportan via Redis
 - Archivos temporales se limpian automáticamente
 - Estados de error se almacenan para debugging
+
+## Despliegue Din\xE1mico de Frontends
+
+Se a\xF1adi\xF3 el servicio `FrontendService` para lanzar contenedores Docker con un front-end est\xE1tico servido por Nginx. El contenedor usa siempre el puerto 80 internamente y se expone a un puerto din\xE1mico en el host.
+
+### Crear la imagen de ejemplo
+
+```bash
+docker build -t my-frontend ./frontend_example
+```
+
+### Lanzar un contenedor
+
+```python
+from app.services.frontend_service import FrontendService
+
+service = FrontendService()
+info = service.deploy_frontend("my-frontend")
+print(f"Frontend disponible en http://localhost:{info['port']}")
+```
+
+### Detener el contenedor
+
+```python
+service.stop_frontend(info["container_id"])
+```

--- a/app/services/frontend_service.py
+++ b/app/services/frontend_service.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import uuid
+import socket
+
+class FrontendService:
+    """Service to dynamically deploy simple front-end containers."""
+
+    def __init__(self, redis_service=None):
+        self.redis_service = redis_service
+
+    @staticmethod
+    def _find_free_port():
+        """Find an available port on the host."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('', 0))
+            return s.getsockname()[1]
+
+    def deploy_frontend(self, image_name: str, port: int = None) -> dict:
+        """Launch a container serving the front-end via nginx.
+
+        Args:
+            image_name: Name of the Docker image with the front-end.
+            port: Optional host port. If not provided, one will be selected.
+
+        Returns:
+            Dictionary with container_id and port used.
+        """
+        if port is None:
+            port = self._find_free_port()
+
+        container_name = f"frontend_{uuid.uuid4().hex[:8]}"
+        try:
+            result = subprocess.run([
+                'docker', 'run', '-d', '--rm',
+                '-p', f'{port}:80',
+                '--name', container_name,
+                image_name
+            ], capture_output=True, text=True, check=True)
+
+            container_id = result.stdout.strip()
+            if self.redis_service:
+                self.redis_service.push_result(container_name, f"running_on:{port}")
+            return {'container_id': container_id, 'port': port}
+        except subprocess.CalledProcessError as e:
+            error_msg = f"Failed to deploy front-end: {e.stderr}"
+            if self.redis_service:
+                self.redis_service.push_result(container_name, error_msg)
+            raise RuntimeError(error_msg)
+
+    def stop_frontend(self, container_id: str):
+        """Stop a running front-end container."""
+        subprocess.run(['docker', 'stop', container_id], check=False)

--- a/app/services/redis_service.py
+++ b/app/services/redis_service.py
@@ -10,6 +10,7 @@ class RedisService:
         self.video_queue = Queue('video_scripts_queue', connection=self.r)
         self.frames_queue = Queue('frames_scripts_queue', connection=self.r)
         self.metadata_queue = Queue('metadata_scripts_queue', connection=self.r)
+        self.frontend_queue = Queue('frontend_queue', connection=self.r)
 
     def get_next_script(self):
         """Obtiene el siguiente script de la cola en Redis (flujo original)."""
@@ -89,3 +90,7 @@ class RedisService:
     def enqueue_metadata_extraction(self, script_id: str, script_content: str, video_id: str):
         """Encola la extracción de metadatos de un video."""
         self.metadata_queue.enqueue(rq_tasks.process_metadata_task, script_id, script_content, video_id)
+
+    def enqueue_frontend_deployment(self, image_name: str):
+        """Encola el despliegue de un frontend estático."""
+        self.frontend_queue.enqueue(rq_tasks.deploy_frontend_task, image_name)

--- a/app/services/rq_tasks.py
+++ b/app/services/rq_tasks.py
@@ -3,12 +3,14 @@ from app.services.script_service import ScriptService
 from app.services.video_audio_service import VideoAudioService
 from app.services.frames_storage_service import FramesStorageService
 from app.services.metadata_storage_service import MetadataStorageService
+from app.services.frontend_service import FrontendService
 
 redis_service = RedisService()
 script_service = ScriptService(redis_service)
 video_audio_service = VideoAudioService(redis_service)
 frames_storage_service = FramesStorageService(redis_service)
 metadata_storage_service = MetadataStorageService(redis_service)
+frontend_service = FrontendService(redis_service)
 
 
 def process_script_task(script_id: str, script_content: str):
@@ -29,3 +31,8 @@ def process_frames_task(script_id: str, script_content: str, video_id: str):
 def process_metadata_task(script_id: str, script_content: str, video_id: str):
     """Process metadata extraction using the MetadataStorageService."""
     metadata_storage_service.process_video_metadata(script_content, script_id, video_id)
+
+
+def deploy_frontend_task(image_name: str):
+    """Deploy a front-end container using the FrontendService."""
+    frontend_service.deploy_frontend(image_name)

--- a/frontend_example/Dockerfile
+++ b/frontend_example/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/frontend_example/index.html
+++ b/frontend_example/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Demo Frontend</title></head>
+<body>
+<h1>Frontend example running inside Docker</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `FrontendService` to launch nginx based front‑ends on dynamic ports
- queue a new `frontend_queue` and task
- document how to build and deploy a simple front-end example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846e15c5aac8324919cb525ac137427